### PR TITLE
ci: fix cleanup job

### DIFF
--- a/.github/workflows/konnect-cleanup.yaml
+++ b/.github/workflows/konnect-cleanup.yaml
@@ -37,8 +37,8 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: run integration tests
-      run: make test.integration
+    - name: run Konnect cleanup ( remove test left overs )
+      run: make cleanup.konnect
       env:
         KONNECT_API_URL: ${{ matrix.konnect-api-url }}
         KONNECT_API_PAT: ${{ secrets.KONNECT_API_PAT }}


### PR DESCRIPTION
<!--

If you want to bump the SDK version, please label your PR with: 'major', 'minor' or 'patch' label.

The automated workflow will take care of the rest.

-->

#### What this PR does / why we need it

Fix CI Konnect clean up job which was incorrectly running tests instead of the cleanup.
