### PR TITLE
ci: add sdk linting for not operations

### DIFF
--- a/.speakeasy/lint.yaml
+++ b/.speakeasy/lint.yaml
@@ -1,0 +1,12 @@
+lintVersion: 2.0.0
+defaultRuleset: kongRuleset
+rulesets:
+  kongRuleset:
+    rulesets:
+      - speakeasy-generation
+    rules:
+      - id: custom-no-not-schemas
+        severity: error
+customRules:
+  paths:
+    - .speakeasy/rules/*.ts

--- a/.speakeasy/rules/nonotschemas.ts
+++ b/.speakeasy/rules/nonotschemas.ts
@@ -1,0 +1,38 @@
+import { Rule, registerRule, createValidationError } from '@speakeasy-api/openapi-linter-types';
+import type { Context, DocumentInfo, RuleConfig, ValidationError } from '@speakeasy-api/openapi-linter-types';
+
+class NoNotSchemas extends Rule {
+  id(): string { return 'custom-no-not-schemas'; }
+  category(): string { return 'structure'; }
+  description(): string {
+    return 'The `not` keyword is unsupported by the SDK generator; any operation reaching it is silently skipped.';
+  }
+  summary(): string { return 'Schemas must not use the `not` keyword'; }
+
+  run(_ctx: Context, docInfo: DocumentInfo, config: RuleConfig): ValidationError[] {
+    const errors: ValidationError[] = [];
+    const idx: any = (docInfo as any).index;
+    if (!idx) return errors;
+
+    for (const group of ['componentSchemas', 'inlineSchemas']) {
+      const arr = idx[group];
+      if (!Array.isArray(arr)) continue;
+      for (const n of arr) {
+        let s: any = n && n.node;
+        if (s && typeof s.getSchema === 'function') s = s.getSchema();   // ← indexed nodes are JSONSchema wrappers
+        if (!s || typeof s.getNot !== 'function') continue;
+        const not = s.getNot();
+        if (not !== null && not !== undefined) {
+          errors.push(createValidationError(
+            config.getSeverity(this.defaultSeverity()),
+            this.id(),
+            'schema uses `not`, which the SDK generator does not support - every operation reaching this schema will be silently dropped from the SDK',
+            typeof s.getRootNode === 'function' ? s.getRootNode() : null
+          ));
+        }
+      }
+    }
+    return errors;
+  }
+}
+registerRule(new NoNotSchemas());

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ generate.deepcopy: controller-gen
 generate.sdk.speakeasy: speakeasy
 	speakeasy run --skip-versioning --skip-testing --minimal --skip-upload-spec
 
+.PHONY: lint.sdk
+lint.sdk: speakeasy
+	speakeasy lint openapi --schema openapi.yaml --ruleset kongRuleset --non-interactive
+
 # NOTE: SDK generation consists of adding the kubebuilder code marker and generating
 #       DeepCopy() for the types that need it and then using speakeasy to generate
 #       the final sdk code.
@@ -155,6 +159,7 @@ generate.sdk:
 	$(MAKE) generate.deepcopy
 	$(MAKE) _generate.omitempty
 	go mod tidy
+	$(MAKE) lint.sdk
 
 # NOTE: Use this when there are breaking changes in the generated SDK code
 #       that require the interfaces and mocks to be regenerated.


### PR DESCRIPTION
<!--

If you want to bump the SDK version, please label your PR with: 'major', 'minor' or 'patch' label.

The automated workflow will take care of the rest.

-->

#### What this PR does / why we need it

Speakeasy (as of 1.791.0) doesn't support `not` in OAS: https://kongstrong.slack.com/archives/C05MLAA216D/p1785334245030279.

This results in generating SDK which silently drops all the related components and functions.

This PR adds a linting rule which detects when OAS adds `not` and fails the build to prevent releasing a broken SDK.

Related PR: https://github.com/Kong/sdk-konnect-go/pull/378/changes#diff-a48932cead5608c6a42224bc607e35faeea6de672243b8d07ae6bdce6874ea74

### Anything else

According to https://kongstrong.slack.com/archives/C05MLAA216D/p1785339957431179?thread_ts=1785334245.030279&cid=C05MLAA216D, speakeasy should be able to provide this soon as a builtin linter rule (ref: GEN-3161)